### PR TITLE
chore: k3s nvidia/cuda base image updated

### DIFF
--- a/zarf-config.yaml
+++ b/zarf-config.yaml
@@ -1,7 +1,7 @@
 package:
   create: 
     set:
-      k3d_version: 5.5.2
-      k3s_version: v1.27.4
-      k3s_gpu_image: ghcr.io/runyontr/packages/rancher/k3s:v1.27.2-k3s1-cuda
+      k3d_version: 5.6.0
+      k3s_version: v1.27.9
+      k3s_gpu_image: ghcr.io/justinthelaw/k3d-gpu-support:v1.27.4-k3s1-cuda
     max_package_size: "1000000000"

--- a/zarf.yaml
+++ b/zarf.yaml
@@ -55,8 +55,6 @@ components:
         - cmd: docker save ghcr.io/k3d-io/k3d-tools:###ZARF_PKG_TMPL_K3D_VERSION### -o k3d-tools-###ZARF_PKG_TMPL_K3D_VERSION###.tar
         - cmd: docker pull --platform linux/amd64 "###ZARF_PKG_TMPL_K3S_GPU_IMAGE###"
         - cmd: docker save "###ZARF_PKG_TMPL_K3S_GPU_IMAGE###" -o k3s-gpu.tar
-        - cmd: docker pull --platform linux/amd64 nvidia/k8s-device-plugin:1.11
-        - cmd: docker save nvidia/k8s-device-plugin:1.11 -o nvidia-device-plugin.tar
 - name: save-images
   required: true
   files:
@@ -70,8 +68,6 @@ components:
       target: k3d-tools.tar
     - source: k3s-gpu.tar
       target: k3s-gpu.tar
-    - source: nvidia-device-plugin.tar
-      target: nvidia-device-plugin.tar
   actions:
     onDeploy:
       after:
@@ -80,7 +76,6 @@ components:
         - cmd: docker load -i k3d-proxy.tar
         - cmd: docker load -i k3d-tools.tar
         - cmd: docker load -i k3s-gpu.tar
-        - cmd: docker load -i nvidia-device-plugin.tar
         - cmd: docker load -i k3s-airgap-images-amd64.tar
 - name: registry-sync
   required: true


### PR DESCRIPTION
See this repo for the base image changes: https://github.com/justinthelaw/k3d-gpu-support

Switched away from Tom's implementation and added multi-platform support (if needed) as well as updated dependencies for the base image.

This was tested in a Kubernetes cluster currently running on Leapfrog-04. GPU support is confirmed using llama-cpp-python, ctransformers, whisper, and a custom [gpu-cupport-test pod](https://github.com/justinthelaw/gpu-support-test).